### PR TITLE
Feat: Exclude and add all

### DIFF
--- a/src_code/go_src/cocommit.go
+++ b/src_code/go_src/cocommit.go
@@ -20,6 +20,8 @@ var sb strings.Builder
 
 func main() {
 
+	all_flag := false
+
 	// Reads a shell env variable :: author_file
 	authors := os.Getenv("author_file")
 
@@ -57,6 +59,12 @@ func main() {
 	sb.WriteString(string(args[0]) + "\n")
 	reg, _ := regexp.Compile("([^:]+):([^:]+)")
 
+	if args[1] == "all" || args[1] == "All" {
+		all_flag = true
+		goto skip_loop
+	}
+
+
 	for _, committer := range args[1:] {
 		if _, ok := users[committer]; ok {
 			sb_author(committer)
@@ -77,7 +85,9 @@ func main() {
 		}
 	}
 
-	if len(excludeMode) > 0 {
+	skip_loop:
+	
+	if len(excludeMode) > 0 || all_flag {
 		for key, user := range users {
 			if !slices.Contains(excludeMode, user.username) {
 				sb_author(key)
@@ -85,8 +95,10 @@ func main() {
 			}
 		}
 	}
+
+
 	// commit msg built
-	commit := sb.String()
+	commit := sb_build()
 
 	print(commit)
 
@@ -103,6 +115,10 @@ func main() {
 		println(string(cmd_output))
 	}
 
+}
+
+func sb_build() string {
+	return sb.String()
 }
 
 func sb_author(committer string) {

--- a/src_code/go_src/cocommit.go
+++ b/src_code/go_src/cocommit.go
@@ -17,10 +17,10 @@ type user struct {
 
 var users = make(map[string]user)
 var sb strings.Builder
+var all_flag = false
 
 func main() {
 
-	all_flag := false
 
 	// Reads a shell env variable :: author_file
 	authors := os.Getenv("author_file")
@@ -88,19 +88,15 @@ func main() {
 	skip_loop:
 	
 	if len(excludeMode) > 0 || all_flag {
-		for key, user := range users {
-			if !slices.Contains(excludeMode, user.username) {
-				sb_author(key)
-				excludeMode = append(excludeMode, user.username)
-			}
-		}
+		add_x_users(excludeMode)
 	}
 
 
 	// commit msg built
 	commit := sb_build()
 
-	print(commit)
+	//NOTE: Uncomment for testing
+	//print(commit)
 
 	// commit shell command
 	cmd := exec.Command("git", "commit", "-m", commit)
@@ -115,6 +111,15 @@ func main() {
 		println(string(cmd_output))
 	}
 
+}
+
+func add_x_users(excludeMode []string) {
+	for key, user := range users {
+		if !slices.Contains(excludeMode, user.username) {
+			sb_author(key)
+			excludeMode = append(excludeMode, user.username)
+		}
+	}
 }
 
 func sb_build() string {

--- a/src_code/go_src/cocommit_test.go
+++ b/src_code/go_src/cocommit_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 )
 
@@ -53,6 +54,7 @@ func Test_add_all(t *testing.T) {
     for k := range users {
         delete(users, k)
     }
+    sb.Reset()
     users["test1"] = user{username: "test1", email: "test1"}
     users["test2"] = user{username: "test2", email: "test2"}  
     users["test3"] = user{username: "test3", email: "test3"} 
@@ -60,13 +62,26 @@ func Test_add_all(t *testing.T) {
     add_x_users([]string{})
 
     commit := sb_build()
-
-    if commit != "\nCo-authored-by: test <test>\nCo-authored-by: test1 <test1>\nCo-authored-by: test2 <test2>\nCo-authored-by: test3 <test3>" {
+    if !strings.Contains(commit, "\nCo-authored-by: test1 <test1>") || 
+    !strings.Contains(commit, "\nCo-authored-by: test2 <test2>") ||
+    !strings.Contains(commit, "\nCo-authored-by: test3 <test3>") {
         t.Fatalf("String built incorrectly. Strings did not match: Created -> %s Expected -> Co-authored-by: test <test>",commit)
     }
 }  
 
+func Test_exclude_user(t *testing.T) {
+    // Reusing users map from last test
+    excludeMode := []string{"test1"}
 
+    sb.Reset()
+
+    add_x_users(excludeMode)
+
+    commit := sb_build()
+    if strings.Contains(commit, "\nCo-authored-by: test1 <test1>") {
+        t.Fatalf("String built incorrectly. Strings did not match: Created -> %s Expected -> Co-authored-by: test <test>",commit)
+    } 
+}
 
 
 

--- a/src_code/go_src/cocommit_test.go
+++ b/src_code/go_src/cocommit_test.go
@@ -37,6 +37,36 @@ func Test_usersInput(t *testing.T) {
     }
     t.Fatalf("process ran with err %v, want exit status 1", err)
 }
+//TODO: Turn this into a fuzz test
+
+func Test_commit_message(t *testing.T) {
+    //authors := make(map[string]user)
+	users["test"] = user{username: "test", email: "test"} 
+    sb_author("test")
+    commit := sb_build()
+    if commit != "\nCo-authored-by: test <test>" {
+        t.Fatalf("String built incorrectly. Strings did not match: Created -> %s Expected -> Co-authored-by: test <test>",commit)
+    }
+}
+//TODO: Turn this into a fuzz test
+func Test_add_all(t *testing.T) {
+    for k := range users {
+        delete(users, k)
+    }
+    users["test1"] = user{username: "test1", email: "test1"}
+    users["test2"] = user{username: "test2", email: "test2"}  
+    users["test3"] = user{username: "test3", email: "test3"} 
+    all_flag = true
+    add_x_users([]string{})
+
+    commit := sb_build()
+
+    if commit != "\nCo-authored-by: test <test>\nCo-authored-by: test1 <test1>\nCo-authored-by: test2 <test2>\nCo-authored-by: test3 <test3>" {
+        t.Fatalf("String built incorrectly. Strings did not match: Created -> %s Expected -> Co-authored-by: test <test>",commit)
+    }
+}  
+
+
 
 
 


### PR DESCRIPTION
This should allow users to use the all arg to add all users from the author file to a commit and or use negations to quickly add all but a certain subset of users
Another branch will add the ability to exclude certains users by default in the all arg see #4

resolves #3 
resolves #1 