### PR TITLE
feat: added commitizen support 

### DIFF
--- a/src_code/go_src/cmd/cmd_test.go
+++ b/src_code/go_src/cmd/cmd_test.go
@@ -32,15 +32,13 @@ func teardown() {
 	os.Setenv("author_file", envVar)
 }
 
-//Skip cobra cmd tests on CI causes problems apparenly idk why
+// Skip cobra cmd tests on CI causes problems apparenly idk why
 // test will be run locally before releasing a new version
 func skipCI(t *testing.T) {
 	if os.Getenv("CI") != "" {
-	  t.Skip("Skipping testing in CI environment")
+		t.Skip("Skipping testing in CI environment")
 	}
-  }
-
-  
+}
 
 func StdoutReader() (chan string, *os.File, *os.File, *os.File) {
 	old := os.Stdout
@@ -111,7 +109,7 @@ func Test_CommitCmd(t *testing.T) {
 		outC <- buf.String()
 	}()
 
-	cmd := rootCmD
+	cmd := rootCmd
 	cmd.SetArgs([]string{"-t", "Test commit message"})
 	cmd.Execute()
 
@@ -142,7 +140,7 @@ func Test_CommitCmdWithM(t *testing.T) {
 		outC <- buf.String()
 	}()
 
-	cmd := rootCmD
+	cmd := rootCmd
 	cmd.SetArgs([]string{"-m", "-t", "Test commit message"})
 	cmd.Execute()
 
@@ -157,6 +155,6 @@ func Test_CommitCmdWithM(t *testing.T) {
 		t.Errorf("Expected to find 'Test commit message' in output but got %s", outStr)
 	}
 
-
 }
+
 // root CMD TEST END

--- a/src_code/go_src/cmd/cz.go
+++ b/src_code/go_src/cmd/cz.go
@@ -56,5 +56,5 @@ var czCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(czCmd)
 	czCmd.Flags().BoolP("print", "p", false, "Print the commit message")
-	czCmd.Flags().BoolP("cli", "c", false, "Use the cli style syntax to add co-authors")
+	czCmd.Flags().BoolP("cli", "c", false, "[co-author1] [co-author2] ...")
 }

--- a/src_code/go_src/cmd/cz.go
+++ b/src_code/go_src/cmd/cz.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/Slug-Boi/cocommit/src_code/go_src/cmd/tui"
+	"github.com/Slug-Boi/cocommit/src_code/go_src/cmd/utils"
+	"github.com/inancgumus/screen"
+	"github.com/spf13/cobra"
+)
+
+// czCmd represents the cz command
+var czCmd = &cobra.Command{
+	Use:   "cz",
+	Short: "Allows for commitizen commit messages",
+	Long: `This command will allow the user to use commitizen to craft the commit message
+	after which the user will be able to add co-authors to the commit message. This will require
+	the user to have commitizen installed on their system.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		var message string
+		var authors []string
+
+		// check if the print flag is set
+		pflag, _ := cmd.Flags().GetBool("print")
+		cflag, _ := cmd.Flags().GetBool("cli")
+
+		// run execute commands again as root run will not call this part
+		message = utils.Cz_Call()
+
+		if cflag {
+			// call the cli style syntax
+			authors = args
+			goto skip_tui
+		}
+
+		// for good measure clear the screen
+		screen.Clear()
+		screen.MoveTopLeft()
+
+		// call tui
+		authors = tui.Entry()
+
+		skip_tui:
+		// build the commit message
+		message = utils.Commit(message, authors)
+
+		// commit the message
+		utils.GitWrapper(message)
+
+		if pflag {
+			fmt.Println(message)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(czCmd)
+	czCmd.Flags().BoolP("print", "p", false, "Print the commit message")
+	czCmd.Flags().BoolP("cli", "c", false, "Use the cli style syntax to add co-authors")
+}

--- a/src_code/go_src/cmd/root.go
+++ b/src_code/go_src/cmd/root.go
@@ -13,7 +13,7 @@ import (
 
 // rootCmd represents the base command when called without any subcommands
 // func RootCmd() *cobra.Command {
-var rootCmD = &cobra.Command{
+var rootCmd = &cobra.Command{
 	Use: `cocommit <commit message> <co-author1> [co-author2] ... ||
   cocommit <commit message> <co-author1:email> [co-author2:email] ... ||
   cocommit <commit message> all ||
@@ -91,7 +91,7 @@ func Execute() {
 	// define users
 	utils.Define_users(author_file)
 
-	err := rootCmD.Execute()
+	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)
 	}
@@ -99,8 +99,8 @@ func Execute() {
 
 func init() {
 	//rootCmD := RootCmd()
-	rootCmD.Flags().BoolP("print", "p", false, "Prints the commit message to the console")
-	rootCmD.Flags().BoolP("test_print", "t", false, "Prints the commit message to the console without running the git commit command")
-	rootCmD.Flags().BoolP("message", "m", false, "Does nothing but allows for -m to be used in the command")
-	rootCmD.Flags().BoolP("authors", "a", false, "Runs the author list TUI")
+	rootCmd.Flags().BoolP("print", "p", false, "Prints the commit message to the console")
+	rootCmd.Flags().BoolP("test_print", "t", false, "Prints the commit message to the console without running the git commit command")
+	rootCmd.Flags().BoolP("message", "m", false, "Does nothing but allows for -m to be used in the command")
+	rootCmd.Flags().BoolP("authors", "a", false, "Runs the author list TUI")
 }

--- a/src_code/go_src/cmd/tui/tui_commit_message.go
+++ b/src_code/go_src/cmd/tui/tui_commit_message.go
@@ -85,7 +85,7 @@ func (m model_cm) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch {
-		case key.Matches(msg, m.keys.EndWithMes) && msg.Alt == true:
+		case key.Matches(msg, m.keys.EndWithMes):
 			return m, tea.Quit
 		case key.Matches(msg, m.keys.NewLine):
 			m.textarea.SetValue(m.textarea.Value() + "\n")

--- a/src_code/go_src/cmd/users.go
+++ b/src_code/go_src/cmd/users.go
@@ -1,13 +1,14 @@
 package cmd
 
 import (
-	"github.com/Slug-Boi/cocommit/src_code/go_src/cmd/tui"
-	"github.com/Slug-Boi/cocommit/src_code/go_src/cmd/utils"
 	"os"
 	"os/exec"
 	"slices"
 	"sort"
 	"strings"
+
+	"github.com/Slug-Boi/cocommit/src_code/go_src/cmd/tui"
+	"github.com/Slug-Boi/cocommit/src_code/go_src/cmd/utils"
 
 	"github.com/spf13/cobra"
 )
@@ -17,43 +18,43 @@ var authorfile = utils.Find_authorfile()
 // usersCmd represents the users command
 func UsersCmd() *cobra.Command {
 	return &cobra.Command{
-	Use:   "users",
-	Short: "Displays all users from the author file located at: " + authorfile,
-	Long:  `Displays all users from the author file located at: ` + authorfile,
-	Run: func(cmd *cobra.Command, args []string) {
-		//TODO: make this print a bit prettier (sort it and maybe use a table)
-		// check if the no pretty print flag is set
-		np, _ := cmd.Flags().GetBool("np")
-		if np {
-			println("List of users:\nFormat: <shortname>/<name> -> Username: <username> Email: <email>")
-			seen_users := []utils.User{}
-			user_sb := []string{}
-			for name, usr := range utils.Users {
-				if !slices.Contains(seen_users, usr) {
-					user_sb = append(user_sb, utils.Users[name].Names+" ->"+" Username: "+usr.Username+" Email: "+usr.Email+"\n")
-					seen_users = append(seen_users, usr)
+		Use:   "users",
+		Short: "Displays all users from the author file located at: " + authorfile,
+		Long:  `Displays all users from the author file located at: ` + authorfile,
+		Run: func(cmd *cobra.Command, args []string) {
+			//TODO: make this print a bit prettier (sort it and maybe use a table)
+			// check if the no pretty print flag is set
+			np, _ := cmd.Flags().GetBool("np")
+			if np {
+				println("List of users:\nFormat: <shortname>/<name> -> Username: <username> Email: <email>")
+				seen_users := []utils.User{}
+				user_sb := []string{}
+				for name, usr := range utils.Users {
+					if !slices.Contains(seen_users, usr) {
+						user_sb = append(user_sb, utils.Users[name].Names+" ->"+" Username: "+usr.Username+" Email: "+usr.Email+"\n")
+						seen_users = append(seen_users, usr)
+					}
 				}
+				sort.Strings(user_sb)
+				println(strings.Join(user_sb, ""))
+				os.Exit(0)
 			}
-			sort.Strings(user_sb)
-			println(strings.Join(user_sb, ""))
-			os.Exit(0)
-		}
-		bat_check := exec.Command("which", "bat")
-		out, _ := bat_check.CombinedOutput()
-		if string(out) == "" {
-			tui.Entry_US(authorfile)
-			os.Exit(0)
-		}
-		bat := exec.Command("bat", authorfile)
-		bat.Stdout = os.Stdout
-		bat.Stderr = os.Stderr
-		bat.Run()
-	},
-}
+			bat_check := exec.Command("which", "bat")
+			out, _ := bat_check.CombinedOutput()
+			if string(out) == "" {
+				tui.Entry_US(authorfile)
+				os.Exit(0)
+			}
+			bat := exec.Command("bat", authorfile)
+			bat.Stdout = os.Stdout
+			bat.Stderr = os.Stderr
+			bat.Run()
+		},
+	}
 }
 
 func init() {
 	usersCmd := UsersCmd()
-	rootCmD.AddCommand(usersCmd)
+	rootCmd.AddCommand(usersCmd)
 	usersCmd.Flags().BoolP("np", "n", false, "No pretty print of the users")
 }

--- a/src_code/go_src/cmd/utils/cz_utils.go
+++ b/src_code/go_src/cmd/utils/cz_utils.go
@@ -1,0 +1,36 @@
+package utils
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+)
+
+func Cz_Call() string {
+
+	// create commitizen command
+	cmd := exec.Command("cz", "commit", "--dry-run", "--write-message-to-file", "msg")
+
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err := cmd.Run()
+	if err != nil {
+		panic(fmt.Sprint(err))
+	}
+
+	file, err := os.OpenFile("msg", os.O_RDONLY, 0644)
+	defer os.Remove("msg")
+	defer file.Close()
+	if err != nil {
+		panic(fmt.Sprint(err))
+	}
+	msg, err := io.ReadAll(file)
+	if err != nil {
+		panic(fmt.Sprint(err))
+	}
+
+	return string(msg)
+}

--- a/src_code/go_src/cmd/utils/cz_utils.go
+++ b/src_code/go_src/cmd/utils/cz_utils.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 func Cz_Call() string {
@@ -18,6 +19,10 @@ func Cz_Call() string {
 
 	err := cmd.Run()
 	if err != nil {
+		// if the user exits the commitizen command, exit the program
+		if strings.Contains(err.Error(), "exit status 8") {
+			os.Exit(0)
+		}
 		panic(fmt.Sprint(err))
 	}
 


### PR DESCRIPTION
Due to the way that the interactive cli call has to be made there is no
good way to automate the tests for it without spending a long time
trying to understand go pipes. since this is more of an extra feature
anyways I am fine with leaving this somewhat untested especially since
it is small isolated code

resolves #24 