### PR TITLE
feat: add version variable and tie update to only outdated version

### DIFF
--- a/ci/build_test_release.go
+++ b/ci/build_test_release.go
@@ -42,6 +42,9 @@ func main() {
 
 	buildDir := test.Directory("/src_d/src/")
 
+	Coco_var := os.Getenv("Coco_Version")
+
+
 	for _, goos := range geese {
 		path := fmt.Sprintf("/dist/")
 		filename := fmt.Sprintf("/dist/cocommit-%s", goos)
@@ -50,7 +53,7 @@ func main() {
 		build := test.
 			WithEnvVariable("GOOS", goos).
 			WithEnvVariable("GOARCH", goarch).
-			WithExec([]string{"go", "build", "-o", filename}).WithEnvVariable("CI", "true")
+			WithExec([]string{"go", "build", "-o", filename, "-ldflags", "-X github.com/Slug-Boi/cocommit/src/cmd.Coco_Version="+Coco_var}).WithEnvVariable("CI", "true")
 
 		buildDir = buildDir.WithDirectory(path, build.Directory(path))
 
@@ -63,7 +66,7 @@ func main() {
 	build := test.
 		WithEnvVariable("GOOS", "darwin").
 		WithEnvVariable("GOARCH", "arm64").
-		WithExec([]string{"go", "build", "-o", filename}).WithEnvVariable("CI", "true")
+		WithExec([]string{"go", "build", "-o", filename, "-ldflags", "-X github.com/Slug-Boi/cocommit/src/cmd.Coco_Version="+Coco_var}).WithEnvVariable("CI", "true")
 
 	buildDir = buildDir.WithDirectory(path, build.Directory(path))
 

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -11,6 +11,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Variables lives in here in case of possible future check of updates on running the CLI
+var Coco_Version string
+
 // rootCmd represents the base command when called without any subcommands
 // func RootCmd() *cobra.Command {
 var rootCmd = &cobra.Command{
@@ -33,6 +36,12 @@ var rootCmd = &cobra.Command{
 		pflag, _ := cmd.Flags().GetBool("print")
 		tflag, _ := cmd.Flags().GetBool("test_print")
 		aflag, _ := cmd.Flags().GetBool("authors")
+		vflag, _ := cmd.Flags().GetBool("version")
+
+		if vflag {
+			fmt.Println("Cocommit version:", Coco_Version)
+			os.Exit(0)
+		}
 
 		if aflag {
 			tui.Entry()
@@ -108,4 +117,5 @@ func init() {
 	rootCmd.Flags().BoolP("test_print", "t", false, "Prints the commit message to the console without running the git commit command")
 	rootCmd.Flags().BoolP("message", "m", false, "Does nothing but allows for -m to be used in the command")
 	rootCmd.Flags().BoolP("authors", "a", false, "Runs the author list TUI")
+	rootCmd.Flags().BoolP("version", "v", false, "Prints the version of the cocommit cli tool")
 }

--- a/src/main.go
+++ b/src/main.go
@@ -1,7 +1,3 @@
-/*
-Copyright © 2024 NAME HERE <EMAIL ADDRESS>
-
-*/
 package main
 
 import "github.com/Slug-Boi/cocommit/src/cmd"


### PR DESCRIPTION
This pull request includes several changes to the `cocommit` CLI tool, focusing on adding version tracking and update checking functionality. The most important changes include adding a version flag to display the current version, modifying the build process to include version information, and implementing update checking against the latest GitHub release.

### Version Tracking and Display:

* [`src/cmd/root.go`](diffhunk://#diff-27b7e7ca994735ab05cd957631bb724f0145e54090994a56f13b47f6d07b7b30R14-R16): Added a `Coco_Version` variable and a `--version` flag to display the current version of the `cocommit` CLI tool. [[1]](diffhunk://#diff-27b7e7ca994735ab05cd957631bb724f0145e54090994a56f13b47f6d07b7b30R14-R16) [[2]](diffhunk://#diff-27b7e7ca994735ab05cd957631bb724f0145e54090994a56f13b47f6d07b7b30R39-R44) [[3]](diffhunk://#diff-27b7e7ca994735ab05cd957631bb724f0145e54090994a56f13b47f6d07b7b30R120)

### Build Process Modifications:

* [`ci/build_test_release.go`](diffhunk://#diff-c75ab1b931458a8962077f535d1d5e8dc3c8d72e06eedc73c807679e7566a3e1R45-R47): Modified the build process to include version information by adding the `Coco_Version` environment variable and using `-ldflags` to set the version in the build output. [[1]](diffhunk://#diff-c75ab1b931458a8962077f535d1d5e8dc3c8d72e06eedc73c807679e7566a3e1R45-R47) [[2]](diffhunk://#diff-c75ab1b931458a8962077f535d1d5e8dc3c8d72e06eedc73c807679e7566a3e1L53-R56) [[3]](diffhunk://#diff-c75ab1b931458a8962077f535d1d5e8dc3c8d72e06eedc73c807679e7566a3e1L66-R69)

### Update Checking:

* [`src/cmd/update.go`](diffhunk://#diff-f7a74bdb21647930a3ab58b74971361aeb9c65bac68220b6847175119795c646R6): Added functionality to check the latest release version on GitHub and compare it with the current version. If an update is available, the user is prompted to proceed with the update. [[1]](diffhunk://#diff-f7a74bdb21647930a3ab58b74971361aeb9c65bac68220b6847175119795c646R6) [[2]](diffhunk://#diff-f7a74bdb21647930a3ab58b74971361aeb9c65bac68220b6847175119795c646R21-R25) [[3]](diffhunk://#diff-f7a74bdb21647930a3ab58b74971361aeb9c65bac68220b6847175119795c646R34-R60) [[4]](diffhunk://#diff-f7a74bdb21647930a3ab58b74971361aeb9c65bac68220b6847175119795c646L37-R70)

### Code Cleanup:

* [`src/main.go`](diffhunk://#diff-9e185f29fa355d7dd8fdd9c9ff1d0723b85206aa7d37c4eec93997005dc291ebL1-L4): Removed outdated comments and metadata from the file header.

resolves #46