### PR TITLE
feat: Check for updates when running commands

### DIFF
--- a/src/cmd/cz.go
+++ b/src/cmd/cz.go
@@ -55,6 +55,10 @@ This will require the user to have commitizen installed on their system.`,
 		}
 		utils.GitWrapper(message, git_flags)
 
+		if update {
+			update_msg()
+		}
+
 		if pflag {
 			fmt.Println(message)
 		}

--- a/src/cmd/users.go
+++ b/src/cmd/users.go
@@ -22,6 +22,10 @@ func UsersCmd() *cobra.Command {
 		Short: "Displays all users from the author file located at:\n" + authorfile,
 		Long:  `Displays all users from the author file located at:` + "\n" + authorfile,
 		Run: func(cmd *cobra.Command, args []string) {
+			if update {
+				update_msg()
+			}
+
 			//TODO: make this print a bit prettier (sort it and maybe use a table)
 			// check if the no pretty print flag is set
 			np, _ := cmd.Flags().GetBool("np")

--- a/src/cmd/utils/author_file_utils.go
+++ b/src/cmd/utils/author_file_utils.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 )
 
 // Author file utils is a package that contains functions that are used to read
@@ -26,6 +27,7 @@ func Find_authorfile() string {
 }
 
 func CheckAuthorFile() string {
+	var cocommit_folder string
 	authorfile := Find_authorfile()
 	if _, err := os.Stat(authorfile); os.IsNotExist(err) {
 		println("Author file not found at: ", authorfile)
@@ -36,18 +38,15 @@ func CheckAuthorFile() string {
 			println("Error reading response")
 		}
 		if response == "y" {
-			if authorfile == "" {
-				fmt.Println("author_file environment variable not set using default location:")
-				config, err := os.UserConfigDir()
-				if err != nil {
-					fmt.Println("Error getting user config directory")
-					os.Exit(1)
-				}
-				authorfile = config + "/cocommit/authors"
-				fmt.Println(authorfile)
-			}
+			parts := strings.Split(authorfile, "/")
+			cocommit_folder = strings.Join(parts[:len(parts)-1], "/")
 
 			// create the author file
+			err := os.Mkdir(cocommit_folder, 0766)
+			if err != nil {
+				fmt.Println("Error creating directory: ", err, cocommit_folder)
+				os.Exit(1)
+			}
 			file, err := os.Create(authorfile)
 			if err != nil {
 				fmt.Println("Error creating file: ", err)

--- a/src/cmd/utils/user_util.go
+++ b/src/cmd/utils/user_util.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 	"strings"
 )
@@ -47,11 +48,19 @@ func Define_users(author_file string) {
 		info := strings.Split(input_str, "|")
 		if len(info) < 4 {
 			if len(info) > 0 {
-				println("Error: User ", info[0], " is missing information")
+				if info[0] == "" {
+					info[0] = "(empty string)"
+				}
+				fmt.Println("Error: User", info[0], "is missing information")
+				} else {
+					fmt.Println("Error: Some user is missing information")
+				}
+				fmt.Println("Please check the author file for proper syntax")
+			if input_str == "" {
+				fmt.Println("empty line found in author file")
 			} else {
-				println("Error: Some user is missing information")
+				fmt.Println("author file input:", input_str)
 			}
-			println("Please check the author file for proper syntax")
 			os.Exit(1)
 		}
 		usr := User{Username: info[2], Email: info[3], Names: info[0] + "/" + info[1]}


### PR DESCRIPTION
This PR will print a message when the user version is out of sync with github version.
Also includes a complete refactor of flag and entry point code in the root command to make the control flow much better and reduce redundant and confusing code (was some especially bad branching going on and gotos). Should also include a fix to the update command and the path check being broken. This should now work by using abs path checks
Resolves #58 
Resolves #60 