### PR TITLE
feat: Add scopes to the program

### DIFF
--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -145,6 +145,7 @@ func Execute() {
 	}
 	// define users
 	utils.Define_users(author_file)
+	utils.Define_git_users()
 
 	err = rootCmd.Execute()
 	if err != nil {

--- a/src/cmd/tui/tui_author.go
+++ b/src/cmd/tui/tui_author.go
@@ -52,13 +52,13 @@ func errorGetMissingFields(m model_ca) {
 	if len(m.inputs) > 0 {
 		for i := 0; i < inpLen; i++ {
 			if m.inputs[i].Value() == "" {
-				m.errorModel.missing = append(m.errorModel.missing, "- "+strings.Split(m.inputs[i].Placeholder," (")[0])
+				m.errorModel.missing = append(m.errorModel.missing, "- "+strings.Split(m.inputs[i].Placeholder, " (")[0])
 			}
 		}
 	} else {
 		m.errorModel.missing = append(m.errorModel.missing, "GIGA ERROR NO INPUTS")
 	}
-	
+
 }
 
 func (e errorModel) View() string {
@@ -68,38 +68,37 @@ func (e errorModel) View() string {
 		sb.WriteString("\nMissing fields: \n")
 		sb.WriteString(strings.Join(e.missing, "\n"))
 	}
-	
-    // Create centered content
-    content := lipgloss.JoinVertical(
-        lipgloss.Left,  // Changed from Center to Left for better alignment
-        sb.String(),
+
+	// Create centered content
+	content := lipgloss.JoinVertical(
+		lipgloss.Left, // Changed from Center to Left for better alignment
+		sb.String(),
 		"\n\n[enter/esc]",
-		
-    )
+	)
 
-    // Create the error box
-    errorBox := lipgloss.NewStyle().
-        Border(lipgloss.RoundedBorder()).
-        BorderForeground(lipgloss.Color("9")).
-        Padding(1, 2).
-        Width(40).
-        Foreground(lipgloss.Color("9")).
-        Background(lipgloss.Color("0")).
+	// Create the error box
+	errorBox := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("9")).
+		Padding(1, 2).
+		Width(40).
+		Foreground(lipgloss.Color("9")).
+		Background(lipgloss.Color("0")).
 		Align(lipgloss.Center).
-        Render(content)
+		Render(content)
 
-    return lipgloss.NewStyle().
-        Padding(1, 0).
-        Render(errorBox)
+	return lipgloss.NewStyle().
+		Padding(1, 0).
+		Render(errorBox)
 }
 
-var parent_m *model
+var parent_m *Model
 
-func createAuthorModel(old_m *model) model_ca {
+func createAuthorModel(old_m *Model) model_ca {
 	parent_m = old_m
 
 	m := model_ca{
-		inputs: make([]textinput.Model, 5),
+		inputs:     make([]textinput.Model, 5),
 		errorModel: intitialErrorModel(),
 	}
 
@@ -137,10 +136,10 @@ func intitialErrorModel() *errorModel {
 	}
 }
 
-func createGHTempAuthorModel(old_m *model, user utils.User) model_ca {
+func createGHTempAuthorModel(old_m *Model, user utils.User) model_ca {
 	parent_m = old_m
 	m := model_ca{
-		inputs: make([]textinput.Model, 2),
+		inputs:     make([]textinput.Model, 2),
 		errorModel: intitialErrorModel(),
 	}
 	var t textinput.Model
@@ -164,11 +163,11 @@ func createGHTempAuthorModel(old_m *model, user utils.User) model_ca {
 	return m
 }
 
-func createGHAuthorModel(old_m *model, user utils.User) model_ca {
+func createGHAuthorModel(old_m *Model, user utils.User) model_ca {
 	parent_m = old_m
 
 	m := model_ca{
-		inputs: make([]textinput.Model, 5),
+		inputs:     make([]textinput.Model, 5),
 		errorModel: intitialErrorModel(),
 	}
 
@@ -195,7 +194,7 @@ func createGHAuthorModel(old_m *model, user utils.User) model_ca {
 			t.SetValue("")
 		case 4:
 			t.Placeholder = "Group tags (e.g. gr1|gr2)"
-			t.SetValue(strings.Join(user.Groups, "|")) 
+			t.SetValue(strings.Join(user.Groups, "|"))
 		}
 
 		m.inputs[i] = t
@@ -205,7 +204,7 @@ func createGHAuthorModel(old_m *model, user utils.User) model_ca {
 }
 
 func EntryGHAuthorModel(user utils.User) {
-	model := createGHAuthorModel(&model{}, user)
+	model := createGHAuthorModel(&Model{}, user)
 
 	print(model.inputs[0].Value())
 
@@ -215,12 +214,11 @@ func EntryGHAuthorModel(user utils.User) {
 	}
 }
 
-
-func tempAuthorModel(old_m *model) model_ca {
+func tempAuthorModel(old_m *Model) model_ca {
 	parent_m = old_m
 
 	m := model_ca{
-		inputs: make([]textinput.Model, 2),
+		inputs:     make([]textinput.Model, 2),
 		errorModel: intitialErrorModel(),
 	}
 
@@ -270,7 +268,7 @@ func updateErrorPopup(m model_ca, msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m model_ca) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if m.errorModel.visible {
 		return updateErrorPopup(m, msg)
-	}	
+	}
 
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
@@ -297,8 +295,8 @@ func (m model_ca) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						return m, nil
 					}
 					if parent_m != nil {
-						return model{list: parent_m.list}, tea.ClearScreen
-						} else {
+						return Model{list: parent_m.list}, tea.ClearScreen
+					} else {
 						m.quitting = true
 						return m, tea.Quit
 					}
@@ -317,7 +315,7 @@ func (m model_ca) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					}
 					if parent_m.keys != nil {
 						tempAuthorToggle = false
-						return model{list: parent_m.list}, tea.ClearScreen
+						return Model{list: parent_m.list}, tea.ClearScreen
 					} else {
 						m.quitting = true
 						tempAuthorToggle = false
@@ -440,7 +438,7 @@ func (m *model_ca) AddAuthor() bool {
 		m.inputs[1].Value() != "" &&
 		m.inputs[2].Value() != "" &&
 		m.inputs[3].Value() != "" {
-	
+
 		var groups []string
 		if m.inputs[4].Value() == "" {
 			groups = []string{}
@@ -455,7 +453,7 @@ func (m *model_ca) AddAuthor() bool {
 			Username:  m.inputs[2].Value(),
 			Email:     m.inputs[3].Value(),
 			Ex:        m.exclude,
-			Groups:   groups,
+			Groups:    groups,
 		}
 
 		utils.CreateAuthor(usr)
@@ -468,7 +466,7 @@ func (m *model_ca) AddAuthor() bool {
 			parent_m.list.InsertItem(len(parent_m.list.Items())+1, item(item_str))
 		}
 		return false
-	} 
+	}
 	return true
 }
 
@@ -480,7 +478,7 @@ func (m *model_ca) TempAddAuthor() bool {
 		parent_m.list.InsertItem(len(parent_m.list.Items())+1, item(item_str))
 		selectToggle(i)
 
-		return false 
+		return false
 	}
 	return true
 }

--- a/src/cmd/tui/tui_github.go
+++ b/src/cmd/tui/tui_github.go
@@ -12,30 +12,29 @@ import (
 
 // Styles
 var (
-	errorStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
-	toggleStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("99"))
+	errorStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
+	toggleStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("99"))
 	activeToggleStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
 )
 
 type GitHubUserModel struct {
-	inputs      []textinput.Model
-	focusIndex  int
-	submitted   bool
-	showError   bool
-	errorMsg    string
+	inputs       []textinput.Model
+	focusIndex   int
+	submitted    bool
+	showError    bool
+	errorMsg     string
 	tempAuthShow bool
-	tempAuth    bool
+	tempAuth     bool
 }
 
-func NewGitHubUserForm(old_m *model) GitHubUserModel {
+func NewGitHubUserForm(old_m *Model) GitHubUserModel {
 	parent_m = old_m
-	
+
 	m := GitHubUserModel{
 		inputs: make([]textinput.Model, 2),
 		tempAuthShow: func() bool {
 			return old_m != nil
 		}(),
-		
 	}
 
 	// GitHub Username (required)
@@ -70,7 +69,7 @@ func (m GitHubUserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return nil, nil
 			}
 			return m, tea.Quit
-		case "ctrl+t":  // Toggle temp mode
+		case "ctrl+t": // Toggle temp mode
 			if m.tempAuthShow {
 				m.tempAuth = !m.tempAuth
 				return m, nil
@@ -91,22 +90,21 @@ func (m GitHubUserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					user.Email = m.inputs[1].Value()
 				}
 				if m.tempAuth {
-					return createGHTempAuthorModel(parent_m,user), tea.ClearScreen
+					return createGHTempAuthorModel(parent_m, user), tea.ClearScreen
 				}
-				return createGHAuthorModel(parent_m,user), tea.ClearScreen
-				
+				return createGHAuthorModel(parent_m, user), tea.ClearScreen
+
 			} else if s == "enter" && m.focusIndex == len(m.inputs) && m.tempAuthShow {
 				//toggle temp mode
 				m.tempAuth = !m.tempAuth
 				return m, nil
 			}
 
-			
 			// Cycle through inputs
 			if s == "up" || s == "shift+tab" {
 				m.focusIndex--
-				} else {
-					m.focusIndex++
+			} else {
+				m.focusIndex++
 			}
 
 			inpNum := len(m.inputs)
@@ -178,14 +176,14 @@ func (m GitHubUserModel) View() string {
 		if m.tempAuth {
 			toggleText = "[X]"
 		}
-		
+
 		toggleBtn := fmt.Sprintf("[ TempAuthor ] %s ", toggleText)
-		
-		if m.focusIndex == len(m.inputs) {  // When toggle is focused
+
+		if m.focusIndex == len(m.inputs) { // When toggle is focused
 			b.WriteString("\n" + focusedStyle.Render(toggleBtn))
-			} else {
-				b.WriteString("\n" + blurredStyle.Render(toggleBtn))
-			}		
+		} else {
+			b.WriteString("\n" + blurredStyle.Render(toggleBtn))
+		}
 	}
 
 	// Submit button

--- a/src/cmd/tui/tui_list.go
+++ b/src/cmd/tui/tui_list.go
@@ -309,12 +309,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
-func (m Model) change_list_items() {
-
-	m.list.SetItems(m.list.Items())
-	m.list.ResetFilter()
-}
-
 func generate_list(scope int) []list.Item {
 	items := []list.Item{}
 	local_dupProtect := map[string]string{}

--- a/src/cmd/tui/tui_list.go
+++ b/src/cmd/tui/tui_list.go
@@ -387,7 +387,7 @@ func (m Model) View() string {
 
 const title_text = "Select authors to add to commit \t|\t"
 
-func listModel() Model {
+func listModel(scope ...int) Model {
 
 	selected = map[string]item{}
 
@@ -396,7 +396,10 @@ func listModel() Model {
 	listKeys := newListKeyMap()
 
 	// Add items to the list
-	items := generate_list(git_scope)
+	if len(scope) == 0 {
+		scope = append(scope, git_scope)
+	}
+	items := generate_list(scope[0])
 
 	sort.Slice(items, func(i, j int) bool {
 		return items[i].(item) < items[j].(item)

--- a/src/cmd/tui/tui_list.go
+++ b/src/cmd/tui/tui_list.go
@@ -27,6 +27,9 @@ var (
 	paginationStyle        = list.DefaultStyles().PaginationStyle.PaddingLeft(4)
 	ActivePaginationDot    = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "170", Dark: "170"})
 	helpStyle              = list.DefaultStyles().HelpStyle.PaddingLeft(4).PaddingBottom(1)
+	git_scope_style        = lipgloss.NewStyle().Foreground(lipgloss.Color("170")).Bold(true)
+	local_scope_style      = lipgloss.NewStyle().Foreground(lipgloss.Color("49")).Bold(true)
+	mixed_scope_style      = lipgloss.NewStyle().Foreground(lipgloss.Color("178")).Bold(true)
 )
 
 type item string
@@ -48,6 +51,7 @@ type listKeyMap struct {
 	deleteAuthor key.Binding
 	tempAdd      key.Binding
 	ghAdd        key.Binding
+	scope        key.Binding
 }
 
 func newListKeyMap() *listKeyMap {
@@ -83,6 +87,10 @@ func newListKeyMap() *listKeyMap {
 		ghAdd: key.NewBinding(
 			key.WithKeys("c"),
 			key.WithHelp("c", "Add GitHub author"),
+		),
+		scope: key.NewBinding(
+			key.WithKeys("S"),
+			key.WithHelp("S", "Change scope"),
 		),
 	}
 }
@@ -126,13 +134,21 @@ func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list
 	fmt.Fprint(w, fn(str))
 }
 
-type model struct {
-	list     list.Model
-	keys     *listKeyMap
-	quitting bool
+const (
+	git_scope = iota
+	local_scope
+	mixed_scope
+)
+
+type Model struct {
+	list       list.Model
+	swap_lists [][]list.Item
+	keys       *listKeyMap
+	quitting   bool
+	scope      int
 }
 
-func (m model) Init() tea.Cmd {
+func (m Model) Init() tea.Cmd {
 	return nil
 }
 
@@ -153,11 +169,11 @@ func toggleNegation() {
 
 var deletion bool
 
-func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if sub_model != nil {
 		var cmd tea.Cmd
 		sub_model, cmd = sub_model.Update(msg)
-		if sub_model_mod, ok := sub_model.(model); ok {
+		if sub_model_mod, ok := sub_model.(Model); ok {
 			m.list = sub_model_mod.list
 			sub_model = nil
 			return m, nil
@@ -234,6 +250,35 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			b = true
 			return m, nil
+
+		case key.Matches(msg, m.keys.scope):
+			if m.scope == git_scope {
+				m.scope = local_scope
+				m.list.Title = title_text + local_scope_style.Render("Scope: LOCAL")
+				if len(m.swap_lists) < 2 {
+					m.swap_lists = append(m.swap_lists, generate_list(local_scope))
+				}
+				m.list.SetItems(m.swap_lists[1])
+				m.list.ResetFilter()
+				return m, nil
+			}
+			if m.scope == local_scope {
+				m.scope = mixed_scope
+				m.list.Title = title_text + mixed_scope_style.Render("Scope: MIXED")
+				if len(m.swap_lists) < 3 {
+					m.swap_lists = append(m.swap_lists, generate_list(mixed_scope))
+				}
+				m.list.SetItems(m.swap_lists[2])
+				m.list.ResetFilter()
+				return m, nil
+			}
+			if m.scope == mixed_scope {
+				m.scope = git_scope
+				m.list.Title = title_text + git_scope_style.Render("Scope: GIT")
+				m.list.SetItems(m.swap_lists[0])
+				m.list.ResetFilter()
+				return m, nil
+			}
 		}
 		// extra key options
 		switch keypress := msg.String(); keypress {
@@ -264,7 +309,64 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
-func (m model) View() string {
+func (m Model) change_list_items() {
+
+	m.list.SetItems(m.list.Items())
+	m.list.ResetFilter()
+}
+
+func generate_list(scope int) []list.Item {
+	items := []list.Item{}
+	local_dupProtect := map[string]string{}
+
+	switch scope {
+	case git_scope:
+		for short, user := range utils.Git_Users {
+			// if items already contains the user, skip it
+			str_user := user.Username + " - " + user.Email
+			if _, ok := local_dupProtect[str_user]; ok {
+				continue
+			}
+			items = append(items, item(str_user))
+			local_dupProtect[str_user] = short
+		}
+	case local_scope:
+		for short, user := range utils.Users {
+			// if items already contains the user, skip it
+			str_user := user.Username + " - " + user.Email
+			if _, ok := dupProtect[str_user]; ok {
+				continue
+			}
+			items = append(items, item(str_user))
+			dupProtect[str_user] = short
+		}
+	case mixed_scope:
+		for short, user := range utils.Users {
+			// if items already contains the user, skip it
+			str_user := user.Username + " - " + user.Email
+			if _, ok := local_dupProtect[str_user]; ok {
+				continue
+			}
+			items = append(items, item(str_user))
+			local_dupProtect[str_user] = short
+		}
+		local_dupProtect = map[string]string{}
+		for short, user := range utils.Git_Users {
+			// if items already contains the user, skip it
+			str_user := user.Username + " - " + user.Email
+			if _, ok := local_dupProtect[str_user]; ok {
+				continue
+			}
+			items = append(items, item(str_user))
+			local_dupProtect[str_user] = short
+		}
+	}
+
+	return items
+
+}
+
+func (m Model) View() string {
 	if sub_model != nil {
 		return sub_model.View()
 	}
@@ -283,8 +385,9 @@ func (m model) View() string {
 	return sb.String()
 }
 
-func listModel() model {
-	items := []list.Item{}
+const title_text = "Select authors to add to commit \t|\t"
+
+func listModel() Model {
 
 	selected = map[string]item{}
 
@@ -293,15 +396,7 @@ func listModel() model {
 	listKeys := newListKeyMap()
 
 	// Add items to the list
-	for short, user := range utils.Users {
-		// if items already contains the user, skip it
-		str_user := user.Username + " - " + user.Email
-		if _, ok := dupProtect[str_user]; ok {
-			continue
-		}
-		items = append(items, item(str_user))
-		dupProtect[str_user] = short
-	}
+	items := generate_list(git_scope)
 
 	sort.Slice(items, func(i, j int) bool {
 		return items[i].(item) < items[j].(item)
@@ -310,7 +405,7 @@ func listModel() model {
 	const defaultWidth = 20
 
 	l := list.New(items, itemDelegate{}, defaultWidth, listHeight)
-	l.Title = "Select authors to add to commit"
+	l.Title = title_text + lipgloss.NewStyle().Foreground(lipgloss.Color("170")).Render("Scope: GIT")
 	l.SetShowStatusBar(false)
 	l.SetFilteringEnabled(true) // Enable filtering
 	l.Styles.Title = titleStyle
@@ -320,6 +415,7 @@ func listModel() model {
 		func() []key.Binding {
 			return []key.Binding{
 				listKeys.selectOne,
+				listKeys.scope,
 			}
 		}
 	l.AdditionalFullHelpKeys = // Add help keys (help menu)
@@ -334,7 +430,18 @@ func listModel() model {
 		}
 	l.Styles.HelpStyle = helpStyle
 
-	return model{list: l, keys: listKeys}
+	model := Model{list: l, swap_lists: [][]list.Item{items}, keys: listKeys, scope: git_scope}
+
+	//TODO: figure out async create
+	// IDEA DO IT WITH CHANNELS  
+	// go func(m *Model) {
+	// 	local_items := generate_list(local_scope)
+	// 	mixed_items := generate_list(mixed_scope)
+	// 	m.swap_lists = append(m.swap_lists, local_items)
+	// 	m.swap_lists = append(m.swap_lists, mixed_items)
+	// }(model)
+
+	return model
 }
 
 // TODO: pass list in as a param to allow for group selection using same template
@@ -363,7 +470,7 @@ func Entry() []string {
 		output = append(output, short)
 	}
 
-	if _, ok := f.(model); ok && len(output) > 0 {
+	if _, ok := f.(Model); ok && len(output) > 0 {
 		return output
 	}
 	return nil

--- a/src/cmd/tui/tui_test.go
+++ b/src/cmd/tui/tui_test.go
@@ -127,7 +127,7 @@ func TestEntryTA(t *testing.T) {
 	setup()
 	defer teardown()
 
-	m := listModel()
+	m := listModel(local_scope)
 
 	// m := tempAuthorModel(&old_m)
 	tm := teatest.NewTestModel(
@@ -218,7 +218,7 @@ func Test_EntryCA_TriggerError(t *testing.T) {
 	setup()
 	defer teardown()
 
-	m := listModel()
+	m := listModel(local_scope)
 
 	tm := teatest.NewTestModel(
 		t, m, teatest.WithInitialTermSize(300, 300),
@@ -256,7 +256,7 @@ func Test_EntryCA(t *testing.T) {
 	setup()
 	defer teardown()
 
-	m := listModel()
+	m := listModel(local_scope)
 
 	// mm := createAuthorModel(&m)
 	tm := teatest.NewTestModel(
@@ -598,7 +598,7 @@ func Test_EntrySelectUsers(t *testing.T) {
 
 	utils.Define_users("author_file_test")
 
-	m := listModel()
+	m := listModel(local_scope)
 	tm := teatest.NewTestModel(
 		t, m, teatest.WithInitialTermSize(300, 300),
 	)
@@ -628,7 +628,7 @@ func Test_EntrySelectAll(t *testing.T) {
 
 	utils.Define_users("author_file_test")
 
-	m := listModel()
+	m := listModel(local_scope)
 	tm := teatest.NewTestModel(
 		t, m, teatest.WithInitialTermSize(300, 300),
 	)
@@ -657,7 +657,7 @@ func Test_EntryNegation(t *testing.T) {
 
 	utils.Define_users("author_file_test")
 
-	m := listModel()
+	m := listModel(local_scope)
 	tm := teatest.NewTestModel(
 		t, m, teatest.WithInitialTermSize(300, 300),
 	)
@@ -686,7 +686,7 @@ func Test_EntryDeleteAuthor(t *testing.T) {
 
 	utils.Define_users("author_file_test")
 
-	m := listModel()
+	m := listModel(local_scope)
 	tm := teatest.NewTestModel(
 		t, m, teatest.WithInitialTermSize(300, 300),
 	)
@@ -719,7 +719,7 @@ func Test_GroupSelection(t *testing.T) {
 	setup()
 	defer teardown()
 
-	m := listModel()
+	m := listModel(local_scope)
 	tm := teatest.NewTestModel(
 		t, m, teatest.WithInitialTermSize(300, 300),
 	)
@@ -756,7 +756,7 @@ func Test_pagination(t *testing.T) {
 		}
 	}
 
-	m := listModel()
+	m := listModel(local_scope)
 
 	tm := teatest.NewTestModel(
 		t, m, teatest.WithInitialTermSize(25, 25),

--- a/src/cmd/tui/tui_test.go
+++ b/src/cmd/tui/tui_test.go
@@ -592,6 +592,119 @@ func Test_EntryCM_Unfocuse(t *testing.T) {
 // tui_commit_message TESTS END
 
 // tui_list TESTS BEGIN
+func Test_ScopesLocal(t *testing.T) {
+	setup()
+	defer teardown()
+
+	m := listModel(local_scope)
+	tm := teatest.NewTestModel(
+		t, m, teatest.WithInitialTermSize(300, 300),
+	)
+	keyPress(tm, "S")
+	keyPress(tm, "space")
+	keyPress(tm, "enter")
+
+	fm := tm.FinalModel(t)
+	m, ok := fm.(Model)
+	if !ok {
+		t.Errorf("Expected model, got %T", fm)
+	}
+
+	if m.scope!= local_scope {
+		t.Errorf("Expected scope to be %v, got %v", local_scope, m.scope)
+	}
+}
+
+func Test_ScopesMixed(t *testing.T) {
+	setup()
+	defer teardown()
+
+	m := listModel(mixed_scope)
+	tm := teatest.NewTestModel(
+		t, m, teatest.WithInitialTermSize(300, 300),
+	)
+	keyPress(tm, "S")
+	keyPress(tm, "S")
+	keyPress(tm, " ")
+	keyPress(tm, "enter")
+
+	fm := tm.FinalModel(t)
+	m, ok := fm.(Model)
+	if !ok {
+		t.Errorf("Expected model, got %T", fm)
+	}
+
+	if m.scope != mixed_scope {
+		t.Errorf("Expected scope to be %v, got %v", mixed_scope, m.scope)
+	}
+}
+
+func Test_ScopesGitBase(t *testing.T) {
+	setup()
+	defer teardown()
+
+	m := listModel(git_scope)
+	tm := teatest.NewTestModel(
+		t, m, teatest.WithInitialTermSize(300, 300),
+	)
+
+	keyPress(tm, " ")
+	keyPress(tm, "enter")
+
+	fm := tm.FinalModel(t)
+	m, ok := fm.(Model)
+	if !ok {
+		t.Errorf("Expected model, got %T", fm)
+	}
+
+	if m.scope != git_scope {
+		t.Errorf("Expected scope to be %v, got %v", git_scope, m.scope)
+	}
+}
+
+func Test_ScopeGitWrapAround(t *testing.T) {
+	setup()
+	defer teardown()
+
+	m := listModel(git_scope)
+	tm := teatest.NewTestModel(
+		t, m, teatest.WithInitialTermSize(300, 300),
+	)
+
+	keyPress(tm, "S")
+	keyPress(tm, "S")
+	keyPress(tm, "S")
+	keyPress(tm, " ")
+	keyPress(tm, "enter")
+
+	fm := tm.FinalModel(t)
+	m, ok := fm.(Model)
+	if !ok {
+		t.Errorf("Expected model, got %T", fm)
+	}
+
+	if m.scope != git_scope {
+		t.Errorf("Expected scope to be %v, got %v", git_scope, m.scope)
+	}
+}
+
+func Test_GenerateList(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mixed := generate_list(mixed_scope)
+	git := generate_list(git_scope)
+
+	if len(mixed) > 2 {
+		t.Errorf("Expected more than 2 items, got %d", len(mixed))
+	}
+
+	if len(git) > 2 {
+		t.Errorf("Expected more than 2 items, got %d", len(git))
+	}
+
+}
+
 func Test_EntrySelectUsers(t *testing.T) {
 	setup()
 	defer teardown()
@@ -620,6 +733,37 @@ func Test_EntrySelectUsers(t *testing.T) {
 		t.Errorf("Expected 1 selected item, got %d", len(selected))
 	}
 
+}
+
+func Test_EntrySelectUnselectSelect(t *testing.T) {
+	setup()
+	defer teardown()
+
+	utils.Define_users("author_file_test")
+
+	m := listModel(local_scope)
+	tm := teatest.NewTestModel(
+		t, m, teatest.WithInitialTermSize(300, 300),
+	)
+	keyPress(tm, " ")
+
+	keyPress(tm, " ")
+
+	keyPress(tm, "enter")
+
+	fm := tm.FinalModel(t)
+	m, ok := fm.(Model)
+	if !ok {
+		t.Errorf("Expected model, got %T", fm)
+	}
+
+	if !m.quitting {
+		t.Errorf("Expected quitting to be true, got %v", m.quitting)
+	}
+
+	if len(selected) != 0 {
+		t.Errorf("Expected 0 selected item, got %d", len(selected))
+	}
 }
 
 func Test_EntrySelectAll(t *testing.T) {

--- a/src/cmd/tui/tui_test.go
+++ b/src/cmd/tui/tui_test.go
@@ -148,7 +148,7 @@ func TestEntryTA(t *testing.T) {
 	keyPress(tm, "esc")
 
 	fm := tm.FinalModel(t)
-	m, ok := fm.(model)
+	m, ok := fm.(Model)
 	if !ok {
 		t.Errorf("Expected model_ca, got %T", fm)
 	}
@@ -242,7 +242,7 @@ func Test_EntryCA_TriggerError(t *testing.T) {
 	keyPress(tm, "esc")
 
 	fm := tm.FinalModel(t)
-	mm, ok := fm.(model)
+	mm, ok := fm.(Model)
 	if !ok {
 		t.Errorf("Expected model_ca, got %T", fm)
 	}
@@ -285,7 +285,7 @@ func Test_EntryCA(t *testing.T) {
 	keyPress(tm, "esc")
 
 	fm := tm.FinalModel(t)
-	m, ok := fm.(model)
+	m, ok := fm.(Model)
 	if !ok {
 		t.Errorf("Expected model, got %T", fm)
 	}
@@ -397,7 +397,6 @@ func TestSubmitWithRequiredField(t *testing.T) {
 	setup()
 	defer teardown()
 
-
 	m := NewGitHubUserForm(nil)
 	tm := teatest.NewTestModel(
 		t, m, teatest.WithInitialTermSize(300, 300),
@@ -405,10 +404,10 @@ func TestSubmitWithRequiredField(t *testing.T) {
 
 	// Simulate filling in the required field
 	tm.Type("Slug-Boi")
-	tm.Send(tea.KeyMsg{Type: tea.KeyTab}) // Move to next field
-	tm.Send(tea.KeyMsg{Type: tea.KeyTab}) // Move to submit button
+	tm.Send(tea.KeyMsg{Type: tea.KeyTab})   // Move to next field
+	tm.Send(tea.KeyMsg{Type: tea.KeyTab})   // Move to submit button
 	tm.Send(tea.KeyMsg{Type: tea.KeyEnter}) // Submit
-	tm.Send(tea.KeyMsg{Type: tea.KeyTab}) 
+	tm.Send(tea.KeyMsg{Type: tea.KeyTab})
 	tm.Send(tea.KeyMsg{Type: tea.KeyTab})
 	tm.Send(tea.KeyMsg{Type: tea.KeyTab})
 	tm.Type("input@mail")
@@ -421,8 +420,6 @@ func TestSubmitWithRequiredField(t *testing.T) {
 	// Check if the form was submitted
 	updated, _ := tm.FinalModel(t).(model_ca)
 
-	
-	
 	if updated.inputs[0].Value() != "th" {
 		t.Errorf("Expected 'Slug-Boi', got '%s'", updated.inputs[0].Value())
 	}
@@ -440,7 +437,7 @@ func TestSubmitWithRequiredField(t *testing.T) {
 // Test temp auth toggle visibility
 func TestTempAuthToggleVisibility(t *testing.T) {
 	// With parent model (should show toggle)
-	m1 := NewGitHubUserForm(&model{})
+	m1 := NewGitHubUserForm(&Model{})
 	if !m1.tempAuthShow {
 		t.Error("tempAuthShow should be true with parent model")
 	}
@@ -454,7 +451,7 @@ func TestTempAuthToggleVisibility(t *testing.T) {
 
 // Test temp auth toggle functionality
 func TestTempAuthToggle(t *testing.T) {
-	m := NewGitHubUserForm(&model{})
+	m := NewGitHubUserForm(&Model{})
 
 	// Initial state
 	if m.tempAuth {
@@ -610,7 +607,7 @@ func Test_EntrySelectUsers(t *testing.T) {
 	keyPress(tm, "enter")
 
 	fm := tm.FinalModel(t)
-	m, ok := fm.(model)
+	m, ok := fm.(Model)
 	if !ok {
 		t.Errorf("Expected model, got %T", fm)
 	}
@@ -640,7 +637,7 @@ func Test_EntrySelectAll(t *testing.T) {
 	keyPress(tm, "enter")
 
 	fm := tm.FinalModel(t)
-	m, ok := fm.(model)
+	m, ok := fm.(Model)
 	if !ok {
 		t.Errorf("Expected model, got %T", fm)
 	}
@@ -669,7 +666,7 @@ func Test_EntryNegation(t *testing.T) {
 	keyPress(tm, "enter")
 
 	fm := tm.FinalModel(t)
-	m, ok := fm.(model)
+	m, ok := fm.(Model)
 	if !ok {
 		t.Errorf("Expected model, got %T", fm)
 	}
@@ -700,7 +697,7 @@ func Test_EntryDeleteAuthor(t *testing.T) {
 	keyPress(tm, "enter")
 
 	fm := tm.FinalModel(t)
-	m, ok := fm.(model)
+	m, ok := fm.(Model)
 	if !ok {
 		t.Errorf("Expected model, got %T", fm)
 	}
@@ -733,7 +730,7 @@ func Test_GroupSelection(t *testing.T) {
 	keyPress(tm, "enter")
 
 	fm := tm.FinalModel(t)
-	_, ok := fm.(model)
+	_, ok := fm.(Model)
 	if !ok {
 		t.Errorf("Expected model, got %T", fm)
 	}
@@ -769,7 +766,7 @@ func Test_pagination(t *testing.T) {
 	tm.Quit()
 
 	fm := tm.FinalModel(t)
-	m, ok := fm.(model)
+	m, ok := fm.(Model)
 	if !ok {
 		t.Errorf("Expected model, got %T", fm)
 	}

--- a/src/cmd/utils/git_scope.go
+++ b/src/cmd/utils/git_scope.go
@@ -1,0 +1,55 @@
+package utils
+
+import (
+	"os/exec"
+	"strings"
+)
+
+func GitCheckAuthors() []User {
+	// check for all authors in git repo
+	cmd := exec.Command("git", "shortlog", "-sne", "--all")
+
+	out, err := cmd.Output()
+	if err != nil {
+		return nil
+	}
+	lines := strings.Split(string(out), "\n")
+
+	cmd = exec.Command("git", "rev-parse", "--show-toplevel")
+	out, err = cmd.Output()
+	if err != nil {
+		return nil
+	}
+	git_folder := strings.TrimSpace(string(out))
+
+	var authors []User
+	for _, line := range lines {
+		parts := strings.Split(line, "\t")
+		if len(line) < 2 {
+			continue
+		}
+		nameAndEmail := strings.Split(parts[1], "<")
+		if len(nameAndEmail) < 2 {
+			continue
+		}
+		name := strings.TrimSpace(nameAndEmail[0])
+		email := strings.TrimSpace(strings.TrimSuffix(nameAndEmail[1], ">"))
+
+		authors = append(authors, User{
+			Shortname: name[:2],
+			Longname:  name,
+			Username: name,
+			Email: email,
+			Ex: false,
+			Groups: func () []string { if git_folder != "" {
+				return []string{git_folder}
+			} else {
+				return []string{}
+			}
+			}(),
+		})
+	}
+
+	return authors
+
+}

--- a/src/cmd/utils/user_util.go
+++ b/src/cmd/utils/user_util.go
@@ -30,6 +30,9 @@ var Users = map[string]User{}
 var DefExclude = []string{}
 var Groups = map[string][]User{}
 
+var Git_Users = map[string]User{}
+var Git_Groups = map[string][]User{}
+
 func ContainsUser(users []User, user User) bool {
     return slices.ContainsFunc(users, func(u User) bool {
         return u.Shortname == user.Shortname && 
@@ -83,6 +86,35 @@ func Define_users(author_file string) {
 					usr_lst := Groups[group]
 					usr_lst = append(usr_lst, usr)
 					Groups[group] = usr_lst
+				}
+			}
+		}
+	}
+}
+
+func Define_git_users() {
+	// wipe the git users map
+	Git_Users = map[string]User{}
+	Git_Groups = map[string][]User{}
+
+	// get all authors from git
+	git_authors := GitCheckAuthors()
+	
+	for _, usr := range git_authors {
+		if _, ok := Users[usr.Shortname]; !ok {
+			Git_Users[usr.Shortname] = usr
+			Git_Users[usr.Longname] = usr
+			
+			group_info := usr.Groups
+			if len(group_info) > 0 {
+				for _, group := range group_info {
+					if Git_Groups[group] == nil {
+						Git_Groups[group] = []User{usr}
+					} else {
+						usr_lst := Git_Groups[group]
+						usr_lst = append(usr_lst, usr)
+						Git_Groups[group] = usr_lst
+					}
 				}
 			}
 		}

--- a/src/cmd/utils/util_test.go
+++ b/src/cmd/utils/util_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"os/exec"
 
 	"github.com/Slug-Boi/cocommit/src/cmd/utils"
 )
@@ -557,7 +558,7 @@ func Test_GitWrapper(t *testing.T) {
 	utils.Define_users("author_file_test")
 
 	// create a temporary file to test git wrapper
-	tmpFile, err := os.CreateTemp("", "test_git_wrapper")
+	tmpFile, err := os.Create("test_git_wrapper")
 	if err != nil {
 		t.Fatalf("Failed to create temporary file: %v", err)
 	}
@@ -580,6 +581,12 @@ func Test_GitWrapper(t *testing.T) {
 	// Test GitWrapper with --dry-run flag
 	authors := []string{"te"}
 	message := "Test commit message for GitWrapper"
+
+	cmd := exec.Command("git", "add", tmpFile.Name())
+	err = cmd.Run()
+	if err != nil {
+		t.Fatalf("Failed to run git add command: %v", err)
+	}
 
 	commit := utils.Commit(message, authors)
 	flags := []string{"-a","--dry-run"}


### PR DESCRIPTION
This feature allows the program to read the committers of any git repo using shortlogs and in the git scope show those users as addable to any commit. The local scope is the old author file scope and the mixed scope is a mix of both. This should allow for much more seamless co-authoring as the user now doesn't need to manually add all fellow committers

Resolves #74 
Resolves #68 